### PR TITLE
Fix incorrect GID assignment in "gid" option for rclone serve docker

### DIFF
--- a/cmd/serve/docker/options.go
+++ b/cmd/serve/docker/options.go
@@ -293,7 +293,7 @@ func getVFSOption(vfsOpt *vfscommon.Options, opt rc.Params, key string) (ok bool
 		intVal, err = opt.GetInt64(key)
 		if err == nil {
 			if intVal >= 0 && intVal <= math.MaxUint32 {
-				vfsOpt.UID = uint32(intVal)
+				vfsOpt.GID = uint32(intVal)
 			} else {
 				err = fmt.Errorf("key %q (%v) overflows uint32", key, intVal)
 			}


### PR DESCRIPTION
#### What is the purpose of this change?

This change fixes a bug in the `rclone serve docker` command where specifying the `gid` option incorrectly assigned the value to the UID field instead of the GID field. 

The issue occurred because the code handling the `gid` case mistakenly reused the same assignment logic as the `uid` case. This fix ensures that the value is assigned to the correct field (`GID`) in the VFS options.

#### Was the change discussed in an issue or in the forum before?

This issue appears to have been introduced in the changes from Pull Request [#8010](https://github.com/rclone/rclone/pull/8010).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- Dockerオプションの処理において、グループID（GID）の割り当てを修正しました。以前は不正確に割り当てられていたGIDが、正しく設定されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->